### PR TITLE
doc(badge) : fix license badge link to LICENSE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/rishabkumar7/the-devops-guide.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/rishabkumar7/the-devops-guide/stargazers/)
 [![GitHub forks](https://img.shields.io/github/forks/rishabkumar7/the-devops-guide.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/rishabkumar7/the-devops-guide/network/)
-[![GitHub license](https://img.shields.io/github/license/rishabkumar7/the-devops-guide.svg)](https://github.com/rishabkumar7/the-devops-guide/blob/main/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/rishabkumar7/the-devops-guide.svg)](https://github.com/rishabkumar7/the-devops-guide/blob/main/LICENSE.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 DevOps Guide is an open-source guide to provide you with an outline of skills needed to learn to get into DevOps. At the end of it you should have the technical knowledge of DevOps.


### PR DESCRIPTION
Small link fix for the license badge, It was redirecting to 404 page not found. Linked it to the correct file