### PR TITLE
Fix GitHub Actions tutorial link on ci-cd.mdx

### DIFF
--- a/pages/guide/ci-cd.mdx
+++ b/pages/guide/ci-cd.mdx
@@ -38,5 +38,5 @@ Continuous Deployment refers to code that, when integrated/merged, is deployed a
 | Resource                                                            | Notes                                                                                       |
 | :------------------------------------------------------------------ | :----------------------------------------------------------------------------------------- |
 | [The IDEAL & Practical CI / CD Pipeline](https://youtu.be/OPwU3UWCxhw)| In this video, we learn what an Ideal CI / CD pipeline looks like. We focus on the concepts instead of specific technologies, and leave it to you to select the framework of your preference to make this pipeline a reality.
-| [GitHub Actions Tutorial - TechWorld with Nana](https://youtu.be/apGV9Kg7ics)|  This tutorial will introduce you to GitHub actions and how we can setup CI-CD
+| [GitHub Actions Tutorial - TechWorld with Nana](https://youtu.be/R8_veQiYBjI)|  This tutorial will introduce you to GitHub actions and how we can setup CI-CD
 


### PR DESCRIPTION
Link was pointing to a different video.

Now it points to TechWorld with Nana's "GitHub Actions Tutorial - Basic Concepts and CI/CD Pipeline with Docker"

I guess that is the intended video?
